### PR TITLE
Modifies service_rpc to use chunked transfer

### DIFF
--- a/lib/grack/server.rb
+++ b/lib/grack/server.rb
@@ -77,8 +77,8 @@ module Grack
           pipe.write(input)
           pipe.close_write
           while !pipe.eof?
-            block = pipe.read(8192) # 8M at a time
-            @res.write encode_chunk(block)        # steam it to the client
+            block = pipe.read(8192)           # 8KB at a time
+            @res.write encode_chunk(block)    # stream it to the client
           end
           @res.write terminating_chunk
         end


### PR DESCRIPTION
https://github.com/gitlabhq/gitlabhq/issues/3079

When downloading/uploading git data, just like with any other web request, a Content-Length header is expected. The problem is the entire response must first be read in order to calculate its length. This is okay with small repos, but breaks servers when serving repos several GBs in size. The entire repo would first be loaded into memory, and then served to the client making it inefficient, unfriendly, (git may appear to hang while the server is loading the repo) and prone to OOM errors.

Chunked transfer solves these issues by doing away with the Content-Length header. It simply grabs data and sends to the client as it is read. The result is immediate download on client side, and negligible memory consumption on server side.

Note that this fix does not provide improvement for single-threaded servers like Thin. It works wonderfully on unicorn, though.
