### PR TITLE
Change the working directory to the repository when executing a service rpc call

### DIFF
--- a/lib/grack/server.rb
+++ b/lib/grack/server.rb
@@ -63,7 +63,7 @@ module Grack
       @res.status = 200
       @res["Content-Type"] = "application/x-git-%s-result" % @rpc
       @res.finish do
-        command = git_command("#{@rpc} --stateless-rpc #{@dir}")
+        command = "cd #{@dir} && " + git_command("#{@rpc} --stateless-rpc #{@dir}")
         IO.popen(command, File::RDWR) do |pipe|
           pipe.write(input)
           pipe.close_write


### PR DESCRIPTION
service_rpc calls IO.popen to create a subprocess to run the git command in. The
sub-process does not use the same CWD as the ruby process but where ever the
script was started from.

If the script was started from a directory that has a broken git repository in it,
git will attempt to process this repository first when starting up. This causes an
error to be thrown and no response to be sent to the client.

This manifests itself to a client as a git clone over http hanging and failing to
proceed.
