### PR TITLE
Safer shell command invocations

### DIFF
--- a/lib/grack/server.rb
+++ b/lib/grack/server.rb
@@ -71,7 +71,7 @@ module Grack
 
       @res.finish do
         command = git_command(%W(#{@rpc} --stateless-rpc #{@dir}))
-        IO.popen(command, File::RDWR, popen_options) do |pipe|
+        IO.popen(popen_env, command, File::RDWR, popen_options) do |pipe|
           pipe.write(input)
           pipe.close_write
           while !pipe.eof?
@@ -264,11 +264,15 @@ module Grack
     end
 
     def capture(command)
-      IO.popen(command, popen_options).read
+      IO.popen(popen_env, command, popen_options).read
     end
 
     def popen_options
-      {chdir: @dir}
+      {chdir: @dir, unsetenv_others: true}
+    end
+
+    def popen_env
+      {'PATH' => ENV['PATH']}
     end
 
     # --------------------------------------


### PR DESCRIPTION
This PR contains the following changes:
- Split commands in tokens using Ruby rather than the shell (to avoid `sh -c "some string I just interpolated"`);
- Keep the process running `Grack::Server` in the same working directory, and only let the subprocesses (system commands) `cd` into another directory;
- Restrict the environment variables passed to Git processes to a minimum: only pass `$PATH`, so that the update hook of gitlab-shell can find `/usr/bin/env ruby`.

/cc @randx @dosire
