### PR TITLE
Abstracted Git logic, checked for actual git repo, added testserver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.swp
+*.swo
 coverage/
+examples/*.git
 pkg/
 *.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-*.swp
-*.swo
 coverage/
 examples/*.git
 pkg/

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gemspec
 
 group :development do
   gem 'rake'
+  gem 'pry'
   gem 'rack-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,26 @@
 PATH
   remote: .
   specs:
-    gitlab-grack (2.0.0.pre)
+    gitlab-grack (2.0.0.rc2)
       rack (~> 1.5.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.0)
     metaclass (0.0.1)
+    method_source (0.8.2)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
     rake (10.1.0)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
@@ -21,5 +28,6 @@ PLATFORMS
 DEPENDENCIES
   gitlab-grack!
   mocha (~> 0.11)
+  pry
   rack-test
   rake

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ end
 namespace :grack do
   desc "Start Grack"
   task :start do
-    system "rackup config.ru -p 8080"
+    system('./bin/testserver')
   end
 end
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+set -e
+
+cd $(dirname "$0")/..
+exec /usr/bin/env pry -Ilib -r grack

--- a/bin/console
+++ b/bin/console
@@ -3,4 +3,4 @@
 set -e
 
 cd $(dirname "$0")/..
-exec /usr/bin/env pry -Ilib -r grack
+exec /usr/bin/env bundle exec pry -Ilib -r grack

--- a/bin/testserver
+++ b/bin/testserver
@@ -1,0 +1,14 @@
+#! /usr/bin/env ruby
+libdir = File.absolute_path( File.join( File.dirname(__FILE__), '../lib' ) )
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
+require 'grack'
+require 'rack'
+root = File.absolute_path( File.join( File.dirname(__FILE__), '../examples' ) )
+app = Grack::Server.new({
+	project_root: root,
+	upload_pack: true,
+	receive_pack:true
+})
+
+Rack::Server.start app: app, Port: 3001

--- a/lib/grack.rb
+++ b/lib/grack.rb
@@ -1,10 +1,5 @@
 require "grack/bundle"
-require 'zlib'
-require 'rack/request'
-require 'rack/response'
-require 'rack/utils'
-require 'time'
-require 'grack/git'
+
 module Grack
 
 end

--- a/lib/grack.rb
+++ b/lib/grack.rb
@@ -1,5 +1,10 @@
 require "grack/bundle"
-
+require 'zlib'
+require 'rack/request'
+require 'rack/response'
+require 'rack/utils'
+require 'time'
+require 'grack/git'
 module Grack
 
 end

--- a/lib/grack/git.rb
+++ b/lib/grack/git.rb
@@ -53,8 +53,13 @@ module Grack
     end
 
     def valid_repo?
-      file_exists = (File.exists?(repo) && File.realpath(repo) == repo)
-      file_exists && ( '.' == execute(%W(rev-parse --git-dir)) )
+      return false unless (File.exists?(repo) && File.realpath(repo) == repo)
+      match = execute(%W(rev-parse --git-dir)).match(/\.$|\.git$/)
+      if match.to_s == '.git'
+        # Since the parent could be a git repo, we want to make sure the actual repo contains a git dir.
+        return false unless Dir.entries(repo).include?('.git')
+      end
+      return !!match
     end
   end
 end

--- a/lib/grack/git.rb
+++ b/lib/grack/git.rb
@@ -1,10 +1,11 @@
 module Grack
   class Git
+
     attr_reader :repo
+
     def initialize(git_path, repo_path)
       @git_path = git_path
       @repo = repo_path
-      @repo = nil unless valid_git_dir?
     end
 
     def update_server_info
@@ -20,12 +21,12 @@ module Grack
     end
 
     def execute(cmd)
-      capture( command(cmd) ).chomp
-    end
-
-    def execute_with_block(cmd)
-      IO.popen(popen_env, command(cmd), File::RDWR, popen_options) do |pipe|
-        yield(pipe)
+      if block_given?
+        IO.popen(popen_env, command(cmd), File::RDWR, popen_options) do |pipe|
+          yield(pipe)
+        end
+      else
+        capture( command(cmd) ).chomp
       end
     end
 
@@ -51,8 +52,9 @@ module Grack
       execute(%W(config #{config_name}))
     end
 
-    def valid_git_dir?
-      '.' == execute(%W(rev-parse --git-dir))
+    def valid_repo?
+      file_exists = (File.exists?(repo) && File.realpath(repo) == repo)
+      file_exists && ( '.' == execute(%W(rev-parse --git-dir)) )
     end
   end
 end

--- a/lib/grack/git.rb
+++ b/lib/grack/git.rb
@@ -1,0 +1,58 @@
+module Grack
+  class Git
+    attr_reader :repo
+    def initialize(git_path, repo_path)
+      @git_path = git_path
+      @repo = repo_path
+      @repo = nil unless valid_git_dir?
+    end
+
+    def update_server_info
+      execute(%W(update-server-info))
+    end
+
+    def command(cmd)
+      [@git_path || 'git'] + cmd
+    end
+
+    def capture(cmd)
+      IO.popen(popen_env, cmd, popen_options).read
+    end
+
+    def execute(cmd)
+      capture( command(cmd) ).chomp
+    end
+
+    def execute_with_block(cmd)
+      IO.popen(popen_env, command(cmd), File::RDWR, popen_options) do |pipe|
+        yield(pipe)
+      end
+    end
+
+    def popen_options
+      {chdir: repo, unsetenv_others: true}
+    end
+
+    def popen_env
+      {'PATH' => ENV['PATH'], 'GL_ID' => ENV['GL_ID']}
+    end
+
+    def config_setting(service_name)
+      service_name = service_name.gsub('-', '')
+      setting = config("http.#{service_name}")
+      if service_name == 'uploadpack'
+        return setting != 'false'
+      else
+        return setting == 'true'
+      end
+    end
+
+    def config(config_name)
+      execute(%W(config #{config_name}))
+    end
+
+    def valid_git_dir?
+      '.' == execute(%W(rev-parse --git-dir))
+    end
+  end
+end

--- a/lib/grack/server.rb
+++ b/lib/grack/server.rb
@@ -100,7 +100,6 @@ module Grack
 
     def get_info_refs
       service_name = get_service_type
-
       if has_access(service_name)
         refs = git.execute([service_name, '--stateless-rpc', '--advertise-refs', git.repo])
 

--- a/lib/grack/server.rb
+++ b/lib/grack/server.rb
@@ -48,7 +48,7 @@ module Grack
       cmd, path, @reqfile, @rpc = match_routing
 
       return render_method_not_allowed if cmd == 'not_allowed'
-      return render_not_found if !cmd
+      return render_not_found unless cmd
 
       @git = get_git(path)
       return render_not_found unless git.valid_repo?
@@ -67,7 +67,7 @@ module Grack
     CRLF = "\r\n"
 
     def service_rpc
-      return render_no_access if !has_access(@rpc, true)
+      return render_no_access unless has_access(@rpc, true)
       input = read_body
 
       @res = Rack::Response.new
@@ -164,7 +164,7 @@ module Grack
     # some of this borrowed from the Rack::File implementation
     def send_file(reqfile, content_type)
       reqfile = File.join(git.repo, reqfile)
-      return render_not_found if !F.exists?(reqfile)
+      return render_not_found unless F.exists?(reqfile)
 
       if reqfile == File.realpath(reqfile)
         # reqfile looks legit: no path traversal, no leading '|'
@@ -206,7 +206,7 @@ module Grack
 
     def get_service_type
       service_type = @req.params['service']
-      return false if !service_type
+      return false unless service_type
       return false if service_type[0, 4] != 'git-'
       service_type.gsub('git-', '')
     end
@@ -230,7 +230,7 @@ module Grack
       if check_content_type
         return false if @req.content_type != "application/x-git-%s-request" % rpc
       end
-      return false if !['upload-pack', 'receive-pack'].include? rpc
+      return false unless ['upload-pack', 'receive-pack'].include? rpc
       if rpc == 'receive-pack'
         return @config[:receive_pack] if @config.include? :receive_pack
       end


### PR DESCRIPTION
There was a TODO to check for a valid git directory so I added that but abstracted out the git logic into it's own class for more modular code and better readability.

Also I added a test server that runs on `rake:start` like the old rackup used to do.