### PR TITLE
Terminator was making tests hang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ branches:
   only:
     - 'master'
 rvm:
-  - 1.9.3-p327
   - 2.0.0
 before_script:
   - "bundle install"

--- a/lib/grack/server.rb
+++ b/lib/grack/server.rb
@@ -82,7 +82,8 @@ module Grack
           pipe.write(input)
           pipe.close_write
 
-          while block = pipe.read(8192)     # 8KB at a time
+          while !pipe.eof?
+            block = pipe.read(8192)     # 8KB at a time
             @res.write encode_chunk(block)  # stream it to the client
           end
 


### PR DESCRIPTION
@DouweM Not using `!pipe.eof?` was causing the tests to hang indefinitely on receive pack rpc. Though it might look cleaner we should not use this assignment conditional when doing chunked streaming.

It took me a sec to figure out why but since we are grabbing the file in 8kb chunks it is likely not going to read the whole file and actually terminate since there will be a gap between the last chunk and the EOF, therefore there should be one more iteration.

What I don't understand is why cloning and pushing still work :confused: 