### PR TITLE
fix rails depedencies on rake >=1.6

### DIFF
--- a/grack.gemspec
+++ b/grack.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Grack::VERSION
 
-  gem.add_dependency("rack", ">= 1.5.1")
+  gem.add_dependency("rack", ">= 1.6")
   gem.add_development_dependency("mocha", "~> 0.11")
 end


### PR DESCRIPTION
this pull request is because miss click
I want to make pull request for my own repo

because it's always error if i want to install it via 
gem 'gitlab-grack', '~> 2.0', '>= 2.0.2'
need to use git repo 
gem 'gitlab-grack' , :git => 'https://github.com/buncismamen/grack.git'  or official repo
